### PR TITLE
Head table fixes

### DIFF
--- a/src/js/components/Table.js
+++ b/src/js/components/Table.js
@@ -179,7 +179,7 @@ function makeTable(tableComponent, tableLens, scope = "scope1") {
       .map((state) => state.settings)
       .compose(dropRepeats(equals)) // Avoid updates to vdom$ when no real change
 
-    const expandOptions$ = modifiedState$
+    const expandOptions$ = state$
       .map((state) => state.core.expandOptions)
       .compose(dropRepeats(equals)) // Avoid updates to vdom$ when no real change
 

--- a/src/js/components/Table.js
+++ b/src/js/components/Table.js
@@ -40,6 +40,7 @@ import {
   merge,
   intersection,
   difference,
+  max,
 } from "ramda"
 // import { tableContent, tableContentLens } from './tableContent/tableContent'
 import isolate from "@cycle/isolate"
@@ -189,31 +190,31 @@ function makeTable(tableComponent, tableLens, scope = "scope1") {
       .events("click")
       .mapTo(5)
       .startWith(0)
-      .fold((x, y) => x + y, 0)
     const min5$ = sources.DOM.select(".min5")
       .events("click")
-      .mapTo(5)
+      .mapTo(-5)
       .startWith(0)
-      .fold((x, y) => x + y, 0)
     const plus10$ = sources.DOM.select(".plus10")
       .events("click")
       .mapTo(10)
       .startWith(0)
-      .fold((x, y) => x + y, 0)
     const min10$ = sources.DOM.select(".min10")
       .events("click")
-      .mapTo(10)
+      .mapTo(-10)
       .startWith(0)
-      .fold((x, y) => x + y, 0)
+
+    const defaultAmountToDisplay$ = newInput$.map(state => parseInt(state.settings.table.count))
+    const amountToDisplay$ = xs
+      .merge(defaultAmountToDisplay$, plus5$, min5$, plus10$, min10$)
+      .fold((x, y) => max(0, x + y), 0)
 
     // ========================================================================
 
     const triggerRequest$ = xs
-      .combine(newInput$, plus5$, min5$, plus10$, min10$)
-      .map(([state, plus5, min5, plus10, min10]) => {
+      .combine(newInput$, amountToDisplay$)
+      .map(([state, amountToDisplay]) => {
         const tableType = state.settings.table.type
-        const cnt =
-          parseInt(state.settings.table.count) + plus5 - min5 + plus10 - min10
+        const cnt = max(1, amountToDisplay)
         // Set a limit on the results depending on the type of table:
         return tableType == "compoundTable"
           ? { ...state, core: { ...state.core, count: { limit: cnt } } }


### PR DESCRIPTION
Fix expanding of options not working

The clicking was only being processed when the input changed causing odd behaviour


Prevent user from setting 0 or negative amount of entries in a table

additionally, prevent the internal state becoming negative if the user would keep pressing '-x',
otherwise, when clicking '+x' the internal state would still be a negative amount and user needs to press
an unknown amount of '+x' before changes are visible

allow internal state to be 0, but always request at least 1
if user adds 5 again, new value should be 5 not 6 so we can't just limit the internal state to 1