### PR TITLE
Rework filter dirty state

### DIFF
--- a/src/js/components/Filter.js
+++ b/src/js/components/Filter.js
@@ -14,7 +14,6 @@ import {
 } from "ramda"
 import { FetchFilters } from "./FetchFilters"
 import debounce from 'xstream/extra/debounce'
-import { dirtyUiReducer } from "../utils/ui"
 
 /**
  * @module components/Filter
@@ -208,7 +207,6 @@ function model(
   filterValuesAction$,
   modifier$,
   filterAction$,
-  state$,
 ) {
 
   /**
@@ -343,19 +341,33 @@ function model(
   }
 
   /**
-   * Output reducer that only outputs to 'filter_output' when changes happened to the opening or closing of the filter top levels
+   * Output reducer that only outputs the minimized state to 'filter_output' when all top level menus are closed
    * @const model/outputReducer$
    * @type {Reducer}
    */
-  const outputReducer$ = filterAction$.map(_ => (prevState) => ({
+  const outputReducer$ = filterAction$
+    .filter((state) => !state.dose && !state.cell && !state.trtType)
+    .map(_ => (prevState) => ({
       ...prevState,
       core: { ...prevState.core, filter_output: minimizeFilterOutput(prevState) },
     }))
 
-  const minimizedCurrentOutput$ = state$.map((state) => minimizeFilterOutput(state))
+  /**
+   * Dirty state reducer, custom version than in ui.js as more logic is required and otherwise need to loop state$ back into model
+   * Uses value change or opening/closing of the filters and compares current state with committed state
+   * 
+   * @const model/dirtyReducer$
+   * @type {Reducer}
+   */
+  const dirtyReducer$ = xs.merge(filterValuesAction$, filterAction$).map(_ => (prevState) => {
+      const minimizedCurrentOutput = minimizeFilterOutput(prevState)
+      const dirty = !equals(minimizedCurrentOutput, prevState.core.filter_output)
 
-  // Logic and reducer stream that monitors if this component became dirty
-  const dirtyReducer$ = dirtyUiReducer(minimizedCurrentOutput$, state$.map(state => state.core.filter_output))
+      return {
+          ...prevState,
+          core: {...prevState.core, dirty: dirty}
+        }
+    })
 
   return xs.merge(
     defaultReducer$,
@@ -574,15 +586,10 @@ function Filter(sources) {
       actions.filterValuesAction$,
       actions.modifier$,
       actions.filterAction$,
-      state$,
   )
 
-  const outputTrigger$ =
+  const outputTrigger$ = 
     state$
-      .filter(
-        (state) =>
-        !state.core.state.dose && !state.core.state.cell && !state.core.state.trtType
-      )
       .map(state => state.core.filter_output)
       .compose(dropRepeats(equals))
 

--- a/src/js/components/Filter.js
+++ b/src/js/components/Filter.js
@@ -192,6 +192,7 @@ function intent(domSource$) {
 
 /**
  * Filters model, control state changes according to actions
+ * set export for unit tests
  * @function model
  * @param {Stream} possibleValues$ object with 'key': 'array of strings'
  * @param {Stream} input$ signature string, used to pass to view for it to check if there is any input at all
@@ -201,7 +202,7 @@ function intent(domSource$) {
  * @param {Stream} state$ readback of full state object used for comparing committed state vs current state, if not identical means ui is dirty
  * @returns {Stream} reducers
  */
-function model(
+export function model(
   possibleValues$,
   input$,
   filterValuesAction$,

--- a/src/js/components/Filter.js
+++ b/src/js/components/Filter.js
@@ -221,6 +221,7 @@ export function model(
       output: {},
       filter_output: {},
       state: {dose: false, cell: false, trtType: false},
+      dirty: false,
     },
   }))
 
@@ -571,11 +572,6 @@ function Filter(sources) {
   const input$ = sources.input
 
   const filterQuery = FetchFilters(sources)
-
-  // Ghost mode, inject changes via external state updates...
-  // const ghostChanges$ = modifiedState$
-  //   .filter((state) => typeof state.core.ghost !== "undefined")
-  //   .compose(dropRepeats())
 
   const actions = intent(sources.DOM)
 

--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -12,7 +12,7 @@ function dirtyUiStream(output$, current$) {
         .map(([output, current]) => !equals(output, current))
         .compose(debounce(10))
         .compose(dropRepeats(equals))
-        .startWith(false)
+        //.startWith(false)
 }
 
 // Reducer dedicated to outputting the dirty state of a component into the component onion

--- a/src/test/FilterTest.js
+++ b/src/test/FilterTest.js
@@ -12,7 +12,6 @@ describe("defaultReducer", function () {
       xs.empty(),
       xs.empty(),
       xs.empty(),
-      xs.empty(),
       xs.empty()
     )
 
@@ -35,7 +34,6 @@ describe("defaultReducer", function () {
       settings: { old: true },
     }
     const reducers$ = model(
-      xs.empty(),
       xs.empty(),
       xs.empty(),
       xs.empty(),
@@ -72,7 +70,6 @@ describe("possibleValuesReducer", function () {
 
     const reducers$ = model(
       possibleValues$,
-      xs.empty(),
       xs.empty(),
       xs.empty(),
       xs.empty(),
@@ -113,7 +110,6 @@ describe("inputReducer", function () {
     const reducers$ = model(
       xs.empty(),
       input$,
-      xs.empty(),
       xs.empty(),
       xs.empty(),
       xs.empty()
@@ -173,7 +169,6 @@ describe("toggleReducer with and without modifier", function () {
       input$,
       filterValuesAction$,
       modifier$,
-      xs.empty(),
       xs.empty()
     )
 

--- a/src/test/FilterTest.js
+++ b/src/test/FilterTest.js
@@ -12,6 +12,7 @@ describe("defaultReducer", function () {
       xs.empty(),
       xs.empty(),
       xs.empty(),
+      xs.empty(),
       xs.empty()
     )
 
@@ -19,7 +20,8 @@ describe("defaultReducer", function () {
       next(f) {
         const newState = f(state)
         assert.deepStrictEqual(newState.core.output, {})
-        assert.deepStrictEqual(newState.settings.filter, { values: {} })
+        assert.deepStrictEqual(newState.core.filter_output, {})
+        assert.deepStrictEqual(newState.core.state, {dose: false, cell: false, trtType: false})
       },
       error(e) {
         done(e)
@@ -37,6 +39,7 @@ describe("defaultReducer", function () {
       xs.empty(),
       xs.empty(),
       xs.empty(),
+      xs.empty(),
       xs.empty()
     )
 
@@ -44,7 +47,6 @@ describe("defaultReducer", function () {
       next(f) {
         const newState = f(state)
         assert.deepStrictEqual(newState.core.output, {})
-        assert.deepStrictEqual(newState.settings.filter, { values: {} })
       },
       error(e) {
         done(e)
@@ -57,7 +59,7 @@ describe("defaultReducer", function () {
 describe("possibleValuesReducer", function () {
   it("Updates the state with the possible values, leaves the rest intact", () => {
     const state = {
-      core: { entry: "test" },
+      core: { entry: "test", dirty: false },
       settings: {},
     }
 
@@ -73,6 +75,7 @@ describe("possibleValuesReducer", function () {
       xs.empty(),
       xs.empty(),
       xs.empty(),
+      xs.empty(),
       xs.empty()
     )
 
@@ -82,9 +85,6 @@ describe("possibleValuesReducer", function () {
         next(f) {
           const newState = f(state)
           assert.deepStrictEqual(newState.core, state.core)
-          assert.deepStrictEqual(newState.settings.filter, {
-            values: possibleValues,
-          })
         },
         error(e) {
           done(e)
@@ -113,6 +113,7 @@ describe("inputReducer", function () {
     const reducers$ = model(
       xs.empty(),
       input$,
+      xs.empty(),
       xs.empty(),
       xs.empty(),
       xs.empty()
@@ -172,10 +173,13 @@ describe("toggleReducer with and without modifier", function () {
       input$,
       filterValuesAction$,
       modifier$,
+      xs.empty(),
       xs.empty()
     )
 
-    const state$ = reducers$.fold((state, reducer) => reducer(state), undefined)
+    // Predefine filters in settings as possible filters will be updated there
+    const defaultFilter = {settings: {filter: {}}}
+    const state$ = reducers$.fold((state, reducer) => reducer(state), defaultFilter)
 
     // The reducers should generate the following sequence for state.core.output
     let expectedOutput = [


### PR DESCRIPTION
Rework dirty reducer so that it doesn't require state$ back into the model
Changed filter on output_filter in main Filter function to have the logic in model, cleaner and needed for the above mentioned changes