### PR TITLE
Use state directly to get default line amount for tables

### DIFF
--- a/src/js/components/Table.js
+++ b/src/js/components/Table.js
@@ -335,7 +335,8 @@ function makeTable(tableComponent, tableLens, scope = "scope1") {
      * @const makeTable/Table/defaultAmountToDisplay$
      * @type {Stream}
      */
-    const defaultAmountToDisplay$ = newInput$.map(state => parseInt(state.settings.table.count))
+    const defaultAmountToDisplay$ = state$.map(state => parseInt(state.settings.table.count))
+      .compose(dropRepeats(equals))
       .startWith(0)
       .compose(pairwise)
       .map((v) => (v[1] - v[0]))


### PR DESCRIPTION
By waiting for new input, the default stream came too late as it only updated after an API call was already made