### PR TITLE
Fix GSKCMP-57, prevent state updates by making sure dirty ui is pre-defined

### DIFF
--- a/src/js/utils/ui.js
+++ b/src/js/utils/ui.js
@@ -12,7 +12,7 @@ function dirtyUiStream(output$, current$) {
         .map(([output, current]) => !equals(output, current))
         .compose(debounce(10))
         .compose(dropRepeats(equals))
-        //.startWith(false)
+        .startWith(false)
 }
 
 // Reducer dedicated to outputting the dirty state of a component into the component onion


### PR DESCRIPTION
startWith was originally removed to solve an issue in the filter tests but this change is no longer needed