### PR TITLE
Tweak correlation plot to define the plot div better so the size can't bounce between two states

### DIFF
--- a/src/js/components/BinnedPlots/CorrelationPlot.js
+++ b/src/js/components/BinnedPlots/CorrelationPlot.js
@@ -5,7 +5,7 @@ import debounce from 'xstream/extra/debounce'
 import { h, p, div, br, label, input, code, table, tr, td, b, h2, button, svg, h1 } from '@cycle/dom';
 import { clone, equals, omit } from 'ramda';
 import { CorrelationVegaSpec } from './CorrelationSpec.js'
-import { widthStream } from '../../utils/utils'
+import { widthStream, widthHeightStream } from '../../utils/utils'
 import { loggerFactory } from '../../utils/logger'
 import { parse } from 'vega-parser'
 
@@ -38,14 +38,14 @@ const isEmptyData = (data) => {
 }
 
 const makeVega = (elementID) => {
-    return div('.card-panel .center-align', [div(elementID)])
+    return div('.card-panel .center-align', { style: { height: '65vh', maxHeight: '75vw', width: '100%' } }, [div(elementID)])
 }
 
 function CorrelationPlot(sources) {
 
     const logger = loggerFactory('plots', sources.onion.state$, 'settings.plots.debug')
 
-    const state$ = sources.onion.state$.debug()
+    const state$ = sources.onion.state$
     const input$ = sources.input
 
     const visibility$ = (el) => sources.DOM.select(el)
@@ -57,7 +57,7 @@ function CorrelationPlot(sources) {
         .remember()
 
     // Size stream
-    const width$ = (el) => widthStream(sources.DOM, el)
+    const size$ = (el) => widthHeightStream(sources.DOM, el)
 
     const resize$ = sources.resize.startWith('go!')
 
@@ -128,8 +128,8 @@ function CorrelationPlot(sources) {
         .filter(data => !isEmptyData(data))
 
     // Ingest the data in the spec and return to the driver
-    const spec$ = xs.combine(nonEmptyData$, width$('#corrplot'), visibility$('#corrplot'), input$, resize$)
-        .map(([data, newwidth, visible]) => ({ spec: CorrelationVegaSpec(data), el: '#corrplot', width: newwidth, height: newwidth-100 }))
+    const spec$ = xs.combine(nonEmptyData$, size$('#corrplot'), visibility$('#corrplot'), input$, resize$)
+        .map(([data, newSize, visible]) => ({ spec: CorrelationVegaSpec(data), el: '#corrplot', width: newSize[0], height: newSize[1] }))
         .compose(debounce(10))
 
     const runtime$ = spec$
@@ -138,7 +138,7 @@ function CorrelationPlot(sources) {
     // ========================================================================
 
     const plotContainer = (plot) => {
-        return div('.col .s8 .offset-s2', {style : { padding: '0px'}}, [div('.col .s12', {style : { margin: '0 0 0 0', padding: 0}}, [
+        return div('.col .s10 .l8 .offset-s1 .offset-l2', {style : { padding: '0px'}}, [div('.col .s12', {style : { margin: '0 0 0 0', padding: 0}}, [
             plot,
         ]) ])
     }

--- a/src/js/main.scss
+++ b/src/js/main.scss
@@ -75,6 +75,10 @@ a:hover #border {
     fill-opacity: 0.5;
 }
 
+div #corrplot {
+    height: 100%
+}
+
 @media print {
     @page {
         margin: 40pt 0pt 40pt 0pt

--- a/src/js/utils/utils.js
+++ b/src/js/utils/utils.js
@@ -1,5 +1,5 @@
 import dropRepeats from 'xstream/extra/dropRepeats'
-import { prop } from 'ramda'
+import { prop, equals } from 'ramda'
 
 // Size stream, make it dependent on the size of container which is managed by CSS.
 // TODO: Make it update immediately, currently only updates on new query
@@ -16,6 +16,23 @@ export function widthStream(domSource$, el) {
             }
         })
         .compose(dropRepeats())
+        .remember()
+        // .debug(log)
+}
+
+export function widthHeightStream(domSource$, el) {
+    return domSource$
+        .select(el)
+        .elements()
+        .map(elements => elements[0])
+        .map(container => {
+            if (container != undefined) {
+                return [container.offsetWidth, container.offsetHeight]
+            } else {
+                return [100, 100]
+            }
+        })
+        .compose(dropRepeats(equals))
         .remember()
         // .debug(log)
 }


### PR DESCRIPTION
Create extra utils function to get both width and height of an element

set height of div to 65vh, so 65% of screen height
set maxHeight to 75vw, so 75% of screen width for tall screens so we don't get a very tall & narrow plot