### PR TITLE
Add statistics duration field in deployments & admin page

### DIFF
--- a/deployments.json
+++ b/deployments.json
@@ -62,7 +62,8 @@
         "url": "http://localhost:8082/ca/"
       },
       "config": {
-        "logoUrl": "https://www.data-intuitive.com/images/logo_white.png"
+        "logoUrl": "https://www.data-intuitive.com/images/logo_white.png",
+        "normalStatisticsResponseTime": 1.0
       }
     }
   },
@@ -139,7 +140,8 @@
         "url": "http://localhost:8082/ca/"
       },
       "config": {
-        "logoUrl": ""
+        "logoUrl": "",
+        "normalStatisticsResponseTime": 1.0
       }
     }
   },
@@ -186,7 +188,8 @@
         "url": "http://localhost:8082/drugbank/"
       },
       "config": {
-        "logoUrl": ""
+        "logoUrl": "",
+        "normalStatisticsResponseTime": 1.0
       }
     }
   }

--- a/src/js/components/Check.js
+++ b/src/js/components/Check.js
@@ -114,14 +114,16 @@ function Check(sources) {
     const responseMetric$ = jobs$
         .map(jobs => differenceWithStatisticsResponses(jobs, LATENCY_FACTOR))
 
+    const maxNormalTime$ = state$.map((state) => state.settings.config.normalStatisticsResponseTime)
+
     // When the performance metric is higher than 1, we show the user a message.
-    const delay$ = responseMetric$
-        .filter(metric => metric > 1)
+    const delay$ = xs.combine(responseMetric$, maxNormalTime$)
+        .filter(([metric, max]) => metric > max)
         .mapTo({ text: 'The cluster seems to be slower than expected.\n Please have patience or try again in 5"...', duration: 15000 })
 
-    const loadedVdom$ = responseMetric$
-        .map(metric =>
-            (metric < 1) ?
+    const loadedVdom$ = xs.combine(responseMetric$, maxNormalTime$)
+        .map(([metric, max]) =>
+            (metric < max) ?
             i('.material-icons .green-text .medium', 'done') :
             i('.material-icons .red-text .medium', 'done')
         )

--- a/src/js/pages/adminSettings.js
+++ b/src/js/pages/adminSettings.js
@@ -233,6 +233,13 @@ export function AdminSettings(sources) {
           type: "text",
           title: "URL for logo image",
           props: {},
+        },
+        {
+          field: "normalStatisticsResponseTime",
+          class: ".input-field",
+          type: "text",
+          title: "Max normal time for statistics query",
+          props: { type: "text" },
         }
       ],
     },


### PR DESCRIPTION
Can be used to configure the correct threshold to declare the cluster being busy instead of a fixed value