### PR TITLE
Move workflow dependent coloring to the style sheet

### DIFF
--- a/src/js/components/CorrelationForm.js
+++ b/src/js/components/CorrelationForm.js
@@ -51,29 +51,29 @@ function CorrelationForm(sources) {
             const query2 = state.form.query2
             return div(
                 [
-                    div('.row .blue .darken-3 .white-text', { style: { margin: '0px', padding: '20px 10px 10px 10px' } }, [
+                    div('.row .WF-header .white-text', { style: { margin: '0px', padding: '20px 10px 10px 10px' } }, [
                         // label('Query: '),
                         div('.Default1 .waves-effect .col .s1 .center-align', [
-                            i('.large  .center-align .material-icons .blue-text', { style: { fontSize: '45px', fontColor: 'gray' } }, 'search'),
+                            i('.large  .center-align .material-icons', { style: { fontSize: '45px', fontColor: 'gray' } }, 'search'),
                         ]),
                         input('.Query1 .col s10 .white-text', { style: { fontSize: '20px' }, props: { type: 'text', value: query1 }, value: query1 }),
                     ]),
                     div([
-                        (!validated1 || query1 == '') ? div('.blue.lighten-3',[checkdom1]) : div()
+                        (!validated1 || query1 == '') ? div('.validation',[checkdom1]) : div()
                     ]),
-                    div('.row .blue .darken-3 .white-text', { style: { margin: '0px', padding: '20px 10px 10px 10px' } }, [
+                    div('.row .WF-header .white-text', { style: { margin: '0px', padding: '20px 10px 10px 10px' } }, [
                         div('.Default2 .waves-effect .col .s1 .center-align', [
-                            i('.large  .center-align .material-icons .blue-text', { style: { fontSize: '45px', fontColor: 'gray' } }, 'search'),
+                            i('.large  .center-align .material-icons', { style: { fontSize: '45px', fontColor: 'gray' } }, 'search'),
                         ]),
                         input('.Query2 .col s10 .white-text', { style: { fontSize: '20px' }, props: { type: 'text', value: query2 }, value: query2 }),
                         (validated1 && validated2)
                             ? div('.SignatureCheck2 .waves-effect .col .s1 .center-align', [
-                                i('.large .material-icons', { style: { fontSize: '45px', fontColor: 'grey' } }, ['play_arrow'])])
+                                i('.large .material-icons .validated', { style: { fontSize: '45px', fontColor: 'grey' } }, ['play_arrow'])])
                             : div('.SignatureCheck2 .col .s1 .center-align', [
-                                i('.large .material-icons .blue-text', { style: { fontSize: '45px', fontColor: 'grey' } }, 'play_arrow')])
+                                i('.large .material-icons', { style: { fontSize: '45px', fontColor: 'grey' } }, 'play_arrow')])
                     ]),
                     div([
-                        (!validated2 || query2 == '') ? div('.blue.lighten-3', [checkdom2]) : div()
+                        (!validated2 || query2 == '') ? div('.validation', [checkdom2]) : div()
                     ])
                 ])
         });

--- a/src/js/components/SignatureForm.js
+++ b/src/js/components/SignatureForm.js
@@ -101,21 +101,21 @@ function view(state$, signatureCheckDom$) {
       const query = state.form.query
       return div(
         [
-          div('.row  .pink .darken-4 .white-text', { style: { padding: '20px 10px 10px 10px' } }, [
+          div('.row .WF-header .white-text', { style: { padding: '20px 10px 10px 10px' } }, [
             // label('Query: '),
             div('.Default .waves-effect .col .s1 .center-align', [
-              i('.large  .center-align .material-icons .pink-text', { style: { fontSize: '45px', fontColor: 'gray' } }, 'search'),
+              i('.large  .center-align .material-icons', { style: { fontSize: '45px', fontColor: 'gray' } }, 'search'),
             ]),
             input('.Query .col s10 .white-text', { style: { fontSize: '20px' }, props: { type: 'text', value: query }, value: query }),
             (validated)
             ? div('.SignatureCheck .waves-effect .col .s1 .center-align', [
-              i('.large .material-icons', { style: { fontSize: '45px', fontColor: 'grey' } }, ['play_arrow'])])
+              i('.large .material-icons .validated', { style: { fontSize: '45px', fontColor: 'grey' } }, ['play_arrow'])])
             : div('.SignatureCheck .col .s1 .center-align', [
-              i('.large .material-icons .pink-text', { style: { fontSize: '45px', fontColor: 'grey' } }, 'play_arrow')])
+              i('.large .material-icons', { style: { fontSize: '45px', fontColor: 'grey' } }, 'play_arrow')])
             // ])
           ]),
           div([
-            (!validated || query == '') ? div([checkdom]) : div()
+            (!validated || query == '') ? div(".validation", [checkdom]) : div()
           ])
         ])
     })

--- a/src/js/components/TreatmentCheck.js
+++ b/src/js/components/TreatmentCheck.js
@@ -125,12 +125,12 @@ function TreatmentCheck(sources) {
     const validated = state.core.validated
     return div([
       div(
-        ".row .genetic .darken-4 .white-text",
+        ".row .WF-header .white-text",
         { style: { padding: "20px 10px 10px 10px" } },
         [
           div(".Default .waves-effect .col .s1 .center-align", [
             i(
-              ".large  .center-align .material-icons .orange-text",
+              ".large  .center-align .material-icons",
               { style: { fontSize: "45px", fontColor: "gray" } },
               "search"
             ),
@@ -152,14 +152,14 @@ function TreatmentCheck(sources) {
           validated
             ? div(".treatmentCheck .waves-effect .col .s1 .center-align", [
                 i(
-                  ".large .material-icons",
+                  ".large .material-icons .validated",
                   { style: { fontSize: "45px", fontColor: "grey" } },
                   ["play_arrow"]
                 ),
               ])
             : div(".treatmentCheck .col .s1 .center-align", [
                 i(
-                  ".large .material-icons .orange-text",
+                  ".large .material-icons",
                   { style: { fontSize: "45px", fontColor: "grey" } },
                   "play_arrow"
                 ),

--- a/src/js/main.scss
+++ b/src/js/main.scss
@@ -20,16 +20,62 @@ main {
 .genetic {
     @extend .red;
     @extend .lighten-5;
+
+    .WF-header {
+        @extend .red;
+        @extend .darken-4;
+    
+        i {
+            @extend .red-text;
+        }
+    }
 }
 
 .compound {
     @extend .orange;
     @extend .lighten-5;
+
+    .WF-header {
+        @extend .orange;
+        @extend .darken-4;
+    
+        i {
+            @extend .orange-text;
+        }
+    }
+}
+
+.ligand {
+    @extend .purple;
+    @extend .lighten-5;
+
+    .WF-header {
+        @extend .purple;
+        @extend .darken-4;
+
+        i {
+            @extend .purple-text;
+        }
+    }
 }
 
 .disease {
     @extend .pink;
     @extend .lighten-5;
+
+    .WF-header {
+        @extend .pink;
+        @extend .darken-4;
+    
+        i {
+            @extend .pink-text;
+        }
+    }
+
+    .validation {
+        @extend .pink;
+        @extend .lighten-5;
+    }
 }
 
 .target {
@@ -40,11 +86,39 @@ main {
 .correlation {
     @extend .blue;
     @extend .lighten-5;
+
+    .WF-header {
+        @extend .blue;
+        @extend .darken-3;
+
+        i {
+            @extend .blue-text;
+        }
+    }
+
+    .validation {
+        @extend .blue;
+        @extend .lighten-3;
+    }
 }
 
 .generic {
     @extend .green;
     @extend .lighten-5;
+
+    .WF-header {
+        @extend .green;
+        @extend .darken-4;
+    
+        i {
+            @extend .green-text;
+        }
+    }
+}
+
+// general style for query 'go' button is that when it is validated that it becomes white
+.WF-header i.validated {
+    @extend .white-text;
 }
 
 img.trt_img {


### PR DESCRIPTION
Simplifies color changes
Removes a bit of styling from the code
Allows Generic treatment form to be correctly styled without having to pass styling strings into sub-components