### PR TITLE
Fix SignatureGenerator displaying '...' even for small signatures

### DIFF
--- a/src/js/components/SignatureGenerator.js
+++ b/src/js/components/SignatureGenerator.js
@@ -135,7 +135,10 @@ function view(state$, request$, response$, geneAnnotationQuery) {
              * @const view/validVdom$/showLimit
              * @type {Number}
              */
-            const showLimit = state.core.showLimit > 0 ? state.core.showLimit : undefined
+            const showLimit =
+              state.core.showLimit > 0 && state.core.showLimit < arr.length
+                ? state.core.showLimit
+                : undefined
 
             /**
              * Display div with a button when the signature is long, otherwise show empty div


### PR DESCRIPTION
tested with PARP2 with 20 significant genes
by setting state.core.showLimit to: 
19 -> shows dots & 'Show more' button
20 -> shows full signature, no 'Show more' button
21 -> shows full signature, no 'Show more' button