### PR TITLE
Force update of input field after autocomplete happened

### DIFF
--- a/src/js/drivers/makeAutocompleteDriver.js
+++ b/src/js/drivers/makeAutocompleteDriver.js
@@ -32,7 +32,9 @@ function makeAutocompleteDriver() {
               ac = M.Autocomplete.init(elem, {
                 data: acInfo.render(acInfo.data),
                 onAutocomplete: function (str) {
-                  listener.next(acInfo.strip(str))
+                  const stripped = acInfo.strip(str)
+                  listener.next(stripped)
+                  elem.value = acInfo.strip(stripped)
                 }
               })
               ac.open()


### PR DESCRIPTION
Autocomplete fills with wrong text, normally overwritten by vdom,
but when the autocompleted text is the same as the full text,
the autocomplete library updates to the full (wrong) text but our code isn't fired properly (as there is no more change)
and thus we can't properly overwrite it later.

Code from the autocomplete library:
let text = el.text().trim();
this.el.value = text;
this.$el.trigger('change');
this._resetAutocomplete();
this.close();
// Handle onAutocomplete callback.
if (typeof this.options.onAutocomplete === 'function') {
    this.options.onAutocomplete.call(this, text);
}

So all we're adding is an extra
this.el.value = 'correct text'