### PR TITLE
Delay loading vdom by 100ms

### DIFF
--- a/src/js/components/Table.js
+++ b/src/js/components/Table.js
@@ -627,6 +627,7 @@ function makeTable(tableComponent, tableLens, scope = "scope1") {
         ])
       )
       .remember()
+      .compose(delay(100))
 
     /**
      * Full vdom content once request is received


### PR DESCRIPTION
State can glitch, especially when using the search queries.
This causes loading vdom to be output and directly being overwritten by init vdom