### PR TITLE
Allow filter values API call coming in later than the input trigger

### DIFF
--- a/src/js/components/Filter.js
+++ b/src/js/components/Filter.js
@@ -374,8 +374,8 @@ export function model(
    * @const model/searchReducer$
    * @type {Reducer}
    */
-  const searchReducer$ = input$.compose(sampleCombine(xs.combine(possibleValues$, search$)))
-    .map(([_, [possibleValues, search]]) => {
+  const searchReducer$ = xs.combine(input$, possibleValues$).compose(sampleCombine(search$))
+    .map(([[_, possibleValues], search]) => {
 
       const matchedFilters = (searchValue, possibleValues) => {
         const values = searchValue.split(',')


### PR DESCRIPTION
In disease & correlation WFs the input trigger comes instantaneously but the API for filter values is still under its way. This means that a regular samplecombine doesn't output the values

first combine input trigger and filter values and then samplecombine the search values