### PR TITLE
Catch error thrown in permission query under Firefox

### DIFF
--- a/src/js/drivers/makeClipboardDriver.js
+++ b/src/js/drivers/makeClipboardDriver.js
@@ -17,8 +17,12 @@ function makeClipboardDriver(provideOwnSink= false) {
   // Firefox by default doesn't allow the clipboard write and doesn't implement the permissions API call
   // so we're kind of forced to assume that if the API call fails that we won't have the necessary permissions
   const queryOpts = { name: "clipboard-write", allowWithoutGesture: false }
-  const copyImagesPermission$ = xs
-    .fromPromise(navigator.permissions.query(queryOpts))
+  const copyImagesPermission$ =  xs
+    .fromPromise(
+      navigator.permissions.query(queryOpts)
+        .then((_) => { return _ })
+        .catch((_) => { return { state: "error" } })
+    )
     .replaceError((_) => xs.of({ state: "error" }))
 
   function clipboardDriver(stream$) {


### PR DESCRIPTION
Firefox doesn't implement 'clipboard-write' but also doesn't allow querying it
Catch the exception that gets thrown.