### PR TITLE
Fix Exporter in generic WF

### DIFF
--- a/src/js/pages/genericTreatment.js
+++ b/src/js/pages/genericTreatment.js
@@ -265,7 +265,7 @@ export default function GenericTreatmentWorkflow(sources) {
 
   const exporter = Exporter({
     ...sources,
-    config: { workflowName: workflow.workflowName },
+    config: { workflowName: workflow.workflowName ?? "" },
   })
 
   /**


### PR DESCRIPTION
Exporter encounters issues when taking 'toUpperCase' from an undefined variable,
so pass an empty string instead of an undefined