### PR TITLE
Remove include of material icons from webpack-material-design-icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix table sample info display of dose & time so the text is properly truncated if the value string is long
 - Hide table sample info fields if the API call returned either empty or "Feature not found"
 - Display single cell information in sample selection and table sample info
+- Solve the 3 invalid font warnings on the console
 
 ## Version 5.3.0
 

--- a/src/js/components/SignatureCheck.js
+++ b/src/js/components/SignatureCheck.js
@@ -8,8 +8,6 @@ import dropRepeats from 'xstream/extra/dropRepeats'
 import debounce from 'xstream/extra/debounce'
 import { loggerFactory } from '../utils/logger'
 
-import { check, flash, play_arrow } from 'webpack-material-design-icons'
-
 const emptyData = {
   body: {
     result: {


### PR DESCRIPTION
The material icons get included through an stylesheet link in index.html And somehow the include in this way caused issues where the font didn't actually get included but instead a line of text was getting linked