### PR TITLE
Check filter data present when updating a sample selection filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version 5.4.1
 
+### Bug fixes
+
+- Fix issue when a sample selection filter is removed triggering an update on unavailable data
+
 ### Minor changes
 
 - Update npm packages and create package-loc.json from scratch, solving many remaining open audit hits

--- a/src/js/components/SampleSelectionFilters.js
+++ b/src/js/components/SampleSelectionFilters.js
@@ -666,6 +666,12 @@ function model(state$, intents, sliderEvents$) {
     const [key, unit, _] = deserialize(id)
     const prevFilterData = prevState.core.filterData
 
+    // Check the data we'll be working with is even available, if not it's probably because a filter element was removed
+    // By returning prevState, we're effectively returning a new state without any invalid data
+    if (prevState.core.filterInfo[key] == undefined || prevFilterData[key] == undefined) {
+      return prevState
+    }
+
     const keyLens = lensProp(key)
     const currentFilterDataKey = viewR(keyLens, prevFilterData)
     


### PR DESCRIPTION
When a sample selection filter is removed by updating the samples with less available filters, the update needs to check if the data is even available