### PR TITLE
Hide sample selection table data when retrieving updated data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fix an issue where data refresh causes the top table expansion functionality locking up caused by added listeners and streams getting interrupted
 - Fix issue when a sample selection filter is removed triggering an update on unavailable data
+- Hide outdated sample selection data when retrieving new data due a new selected perturbation
 
 ### Minor changes
 

--- a/src/js/components/SampleSelection.js
+++ b/src/js/components/SampleSelection.js
@@ -268,7 +268,7 @@ function SampleSelection(sources) {
   const loadingState$ = state$
     .map((state) => ({
       ...state,
-      core: { ...state.core, data: []}
+      core: { ...state.core, data: [], usageData: [] }
     }))
 
   const request$ = newInput$.map((state) => {
@@ -435,8 +435,8 @@ function SampleSelection(sources) {
   const initVdom$ = emptyState$.mapTo(div())
 
   const loadingVdom$ = request$
-    .compose(sampleCombine(loadingState$, sampleFilters.DOM))
-    .map(([_, state, filtersDom]) =>
+    .compose(sampleCombine(loadingState$))
+    .map(([_, state]) =>
       // Use the same makeTable function, pass a initialization=true parameter and a body DOM with preloading
       makeFiltersAndTable(
         state,
@@ -448,7 +448,7 @@ function SampleSelection(sources) {
           ),
         ]),
         true,
-        filtersDom
+        div()
       )
     )
     .remember()


### PR DESCRIPTION
Also completely remove sample selection filters in the loading vdom