### PR TITLE
Develop 5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## Version 5.4.1
+
+### Minor changes
+
+- Update npm packages and create package-loc.json from scratch, solving many remaining open audit hits
+
 ## Version 5.4.0
 
 ### Functionality

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fix an issue where data refresh causes the top table expansion functionality locking up caused by added listeners and streams getting interrupted
 - Fix issue when a sample selection filter is removed triggering an update on unavailable data
+- Hide outdated sample selection data when retrieving new data due a new selected perturbation
 
 ### Minor changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Minor changes
 
 - Update npm packages and create package-loc.json from scratch, solving many remaining open audit hits
+- Update Ramda to 0.28.0, fix `merge` being removed in favour of `mergeRight` and `contains` in favour of `includes`
 
 ## Version 5.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version 5.4.1
 
+### Bug fixes
+
+- Fix issue when a sample selection filter is removed triggering an update on unavailable data
+
 ### Minor changes
 
 - Update npm packages and create package-loc.json from scratch, solving many remaining open audit hits

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug fixes
 
+- Fix an issue where data refresh causes the top table expansion functionality locking up caused by added listeners and streams getting interrupted
 - Fix issue when a sample selection filter is removed triggering an update on unavailable data
 
 ### Minor changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -4237,9 +4237,9 @@
             "integrity": "sha512-LkBLIB8HxauuR6l7SigDZbvdjNWErRfauvCs7Rgp4Xh/oiA89IHTjj/SvUowywXnldISKWIZfxaqs/6lGEB+gw=="
         },
         "ramda": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.2.tgz",
-            "integrity": "sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA=="
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
+            "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA=="
         },
         "randombytes": {
             "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
         "cyclic-router": "^6.0.0",
         "helmet": "^6.0.0",
         "materialize-css": "^1.0.0",
-        "ramda": "^0.27.2",
+        "ramda": "^0.28.0",
         "switch-path": "^1.2.0",
         "vega": "^5.22.1",
         "vega-parser": "^6.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "LuciusWeb",
-    "version": "5.4.1-alpha1",
+    "version": "5.4.1",
     "description": "Web interface for ComPass aka Lucius",
     "repository": {
         "type": "git",

--- a/src/js/components/AdminStatus.js
+++ b/src/js/components/AdminStatus.js
@@ -1,11 +1,8 @@
-import { a, div, br, label, input, p, button, code, pre, i, span } from '@cycle/dom'
+import { i, span } from '@cycle/dom'
 import xs from 'xstream'
-import isolate from '@cycle/isolate'
-import { mergeWith, merge } from 'ramda'
-import { clone, equal, equals, mergeAll, omit } from 'ramda';
+import { equals, omit } from 'ramda';
 import dropRepeats from 'xstream/extra/dropRepeats'
 import debounce from 'xstream/extra/debounce'
-import sampleCombine from 'xstream/extra/sampleCombine'
 
 // Alert the user when last response time is 1.5 times higher than the minimum
 // over the history of the jobserver.

--- a/src/js/components/CompoundTable/CompoundInfo.js
+++ b/src/js/components/CompoundTable/CompoundInfo.js
@@ -1,9 +1,6 @@
 import xs from 'xstream'
 import { i, a, h, p, div, br, label, input, code, table, tr, td, b, h2, button, svg, h1, th, thead, tbody, li, span, img, em } from '@cycle/dom'
-import { log } from '../../utils/logger'
-import { merge } from 'ramda'
-import dropRepeats from 'xstream/extra/dropRepeats'
-import { stateDebug } from '../../utils/utils'
+import { mergeRight } from 'ramda'
 import { safeModelToUi } from '../../modelTranslations'
 
 export function CompoundInfo(sources) {
@@ -32,8 +29,8 @@ export function CompoundInfo(sources) {
     const detail = (sample, props, blur) => {
         let hStyle = { style: { margin: '0px', fontWeight: 'bold' } }
         let pStyle = { style: { margin: '0px' } }
-        let hStylewBlur = { style: merge(blur, { margin: '0px', fontWeight: 'bold' }) }
-        let pStylewBlur = { style: merge(blur, { margin: '0px' }) }
+        let hStylewBlur = { style: mergeRight(blur, { margin: '0px', fontWeight: 'bold' }) }
+        let pStylewBlur = { style: mergeRight(blur, { margin: '0px' }) }
         let urlSourire = props.sourire.url
         let url = urlSourire + encodeURIComponent(sample.compound_smiles).replace(/%20/g, '+')
         return div('.col .s12', [
@@ -46,7 +43,7 @@ export function CompoundInfo(sources) {
                 p('.s12', pStylewBlur, entry('InchiKey: ', sample.compound_inchikey)),
                 p('.s12', pStylewBlur, entry('Targets: ', sample.compound_targets.join(', ')))
             ]),
-            div('.col .s4 .offset-s8 .l4', { style: merge(blur, { margin: '20px 0px 0px 0px' }) }, [
+            div('.col .s4 .offset-s8 .l4', { style: mergeRight(blur, { margin: '20px 0px 0px 0px' }) }, [
                 (sample.compound_smiles != null && sample.compound_smiles != 'NA' && sample.compound_smiles != 'No Smiles') ?
                 img('.col .s12 .valign', { props: { src: url } }) :
                 ''

--- a/src/js/components/GeneAnnotationQuery.js
+++ b/src/js/components/GeneAnnotationQuery.js
@@ -1,7 +1,5 @@
 import { loggerFactory } from '../utils/logger'
 import xs from 'xstream'
-import { keys, values, filter, head, equals, map, prop, clone, omit, merge } from 'ramda'
-import dropRepeats from 'xstream/extra/dropRepeats'
 import { i, em, p, div, br, label, input, code, table, tr, td, b, h2, button, textarea, a, ul, li, span, th, thead, tbody, h3, h4 } from '@cycle/dom';
 import { absGene, titleCase } from '../utils/utils'
 import sampleCombine from 'xstream/extra/sampleCombine'

--- a/src/js/components/SampleSelection.js
+++ b/src/js/components/SampleSelection.js
@@ -14,11 +14,10 @@ import {
   p,
   i,
 } from "@cycle/dom"
-import { clone, equals, merge, sortWith, prop, ascend, descend, keys, length, includes, anyPass, allPass, filter } from "ramda"
+import { clone, equals, mergeRight, sortWith, prop, ascend, descend, keys, length, includes, anyPass, allPass, filter } from "ramda"
 import xs from "xstream"
 import isolate from "@cycle/isolate"
 import dropRepeats from "xstream/extra/dropRepeats"
-import debounce from 'xstream/extra/debounce'
 import { loggerFactory } from "../utils/logger"
 import { TreatmentAnnotation } from "./TreatmentAnnotation"
 import { SampleSelectionFilters, SampleSelectionFiltersLens } from "./SampleSelectionFilters"
@@ -463,7 +462,7 @@ function SampleSelection(sources) {
   const vdom$ = dirtyWrapperStream( state$, xs.merge(initVdom$, loadingVdom$, loadedVdom$))
 
   const dataReducer$ = data$.map((data) => (prevState) => {
-    const newData = data.map((el) => merge(el, { use: true, hide: false }))
+    const newData = data.map((el) => mergeRight(el, { use: true, hide: false }))
     const hiddenData = hideFilteredData(newData, prevState.core.filtersObject)
     return {
       ...prevState,

--- a/src/js/components/SampleSelection.js
+++ b/src/js/components/SampleSelection.js
@@ -268,7 +268,7 @@ function SampleSelection(sources) {
   const loadingState$ = state$
     .map((state) => ({
       ...state,
-      core: { ...state.core, data: []}
+      core: { ...state.core, data: [], usageData: [] }
     }))
 
   const request$ = newInput$.map((state) => {
@@ -435,8 +435,8 @@ function SampleSelection(sources) {
   const initVdom$ = emptyState$.mapTo(div())
 
   const loadingVdom$ = request$
-    .compose(sampleCombine(loadingState$, sampleFilters.DOM))
-    .map(([_, state, filtersDom]) =>
+    .compose(sampleCombine(loadingState$))
+    .map(([_, state]) =>
       // Use the same makeTable function, pass a initialization=true parameter and a body DOM with preloading
       makeFiltersAndTable(
         state,
@@ -448,7 +448,7 @@ function SampleSelection(sources) {
           ),
         ]),
         true,
-        filtersDom
+        div()
       )
     )
     .remember()

--- a/src/js/components/SampleSelectionFilters.js
+++ b/src/js/components/SampleSelectionFilters.js
@@ -666,6 +666,12 @@ function model(state$, intents, sliderEvents$) {
     const [key, unit, _] = deserialize(id)
     const prevFilterData = prevState.core.filterData
 
+    // Check the data we'll be working with is even available, if not it's probably because a filter element was removed
+    // By returning prevState, we're effectively returning a new state without any invalid data
+    if (prevState.core.filterInfo[key] == undefined || prevFilterData[key] == undefined) {
+      return prevState
+    }
+
     const keyLens = lensProp(key)
     const currentFilterDataKey = viewR(keyLens, prevFilterData)
     

--- a/src/js/components/SampleTable/SampleInfo.js
+++ b/src/js/components/SampleTable/SampleInfo.js
@@ -7,7 +7,7 @@ import {
   img,
   i,
 } from "@cycle/dom"
-import { merge } from "ramda"
+import { mergeRight } from "ramda"
 import { safeModelToUi } from "../../modelTranslations"
 
 import img_trt_cp          from "/images/treatmentTypes/TRT_CP.png"
@@ -394,7 +394,7 @@ export function SampleInfo(sources) {
   const rowDetail = (sample, props, blur, informationDetails, zoomInfo) => {
     let hStyle = { style: { margin: "0px", fontWeight: "bold" } }
     let pStyle = { style: { margin: "0px" } }
-    let pStylewBlur = { style: merge(blur, { margin: "0px" }) }
+    let pStylewBlur = { style: mergeRight(blur, { margin: "0px" }) }
     const _filters = sample.filters != undefined ? sample.filters : []
 
     const origDose = _filters.find(e => e.key == "orig_dose")?.value ?? "N/A"
@@ -505,7 +505,7 @@ export function SampleInfo(sources) {
         div(".col .s12 .m6 .l4", { style: { margin: "15px 0px 0px 0px" } }, samplePart),
         div(".col .s12 .m6 .l4", { style: { margin: "15px 0px 0px 0px" } }, treatmentPart),
         div(".col .s12 .offset-s8 .offset-m8 .l4",
-          {style: merge(blur, { margin: "20px 0px 0px 0px" }) },
+          {style: mergeRight(blur, { margin: "20px 0px 0px 0px" }) },
           visualizeSmilesPart
         ),
         div(".col .s12", { style: { margin: "15px 0px 0px 0px" } }, expandingFiltersAndReplicationPart),
@@ -514,7 +514,7 @@ export function SampleInfo(sources) {
         div(".col .s12 .m6 .l4", { style: { margin: "15px 0px 0px 0px" } }, samplePart),
         div(".col .s12 .m6 .l4", { style: { margin: "15px 0px 0px 0px" } }, treatmentPart),
         div(".col .s12 .m12 .l2 .push-l2 .hide-on-med-and-down .center-align",
-          { style: merge(blur, { height: "100%", "margin-top": "30px"}) },
+          { style: mergeRight(blur, { height: "100%", "margin-top": "30px"}) },
           visualizeTextPart
         ),
         div(".col .s12", { style: { margin: "15px 0px 0px 0px" } }, expandingFiltersAndReplicationPart),
@@ -523,7 +523,7 @@ export function SampleInfo(sources) {
         div(".col .s12 .m6 .l4", { style: { margin: "15px 0px 0px 0px" } }, samplePart),
         div(".col .s12 .m6 .l4", { style: { margin: "15px 0px 0px 0px" } }, treatmentPart),
         div(".col .s12 .m12 .l2 .push-l2 .hide-on-med-and-down .center-align",
-          { style: merge(blur, { height: "100%", "margin-top": "30px"}) },
+          { style: mergeRight(blur, { height: "100%", "margin-top": "30px"}) },
           visualizeTextPart
         ),
         div(".col .s12", { style: { margin: "15px 0px 0px 0px" } }, expandingFiltersAndReplicationPart),
@@ -532,7 +532,7 @@ export function SampleInfo(sources) {
         div(".col .s12 .m6 .l4", { style: { margin: "15px 0px 0px 0px" } }, samplePart),
         div(".col .s12 .m6 .l4", { style: { margin: "15px 0px 0px 0px" } }, treatmentPart),
         div(".col .s12 .m12 .l2 .push-l2 .hide-on-med-and-down .center-align",
-          { style: merge(blur, { height: "100%", "margin-top": "30px"}) },
+          { style: mergeRight(blur, { height: "100%", "margin-top": "30px"}) },
           visualizeTextPart
         ),
         div(".col .s12", { style: { margin: "15px 0px 0px 0px" } }, expandingFiltersAndReplicationPart),
@@ -541,7 +541,7 @@ export function SampleInfo(sources) {
         div(".col .s12 .m6 .l4", { style: { margin: "15px 0px 0px 0px" } }, samplePart),
         div(".col .s12 .m6 .l4", { style: { margin: "15px 0px 0px 0px" } }, treatmentPart),
         div(".col .s12 .m12 .l2 .push-l2 .hide-on-med-and-down .center-align",
-          { style: merge(blur, { height: "100%", "margin-top": "30px"}) },
+          { style: mergeRight(blur, { height: "100%", "margin-top": "30px"}) },
           visualizeTextPart
         ),
         div(".col .s12", { style: { margin: "15px 0px 0px 0px" } }, expandingFiltersAndReplicationPart),
@@ -550,7 +550,7 @@ export function SampleInfo(sources) {
         div(".col .s12 .m6 .l4", { style: { margin: "15px 0px 0px 0px" } }, samplePart),
         div(".col .s12 .m6 .l4", { style: { margin: "15px 0px 0px 0px" } }, treatmentPart),
         div(".col .s12 .offset-s8 .offset-m8 .l4",
-          {style: merge(blur, { margin: "20px 0px 0px 0px" }) },
+          {style: mergeRight(blur, { margin: "20px 0px 0px 0px" }) },
           visualizeSmilesPart
         ),
         div(".col .s12", { style: { margin: "15px 0px 0px 0px" } }, expandingFiltersAndReplicationPart),

--- a/src/js/components/SampleTable/SampleInfo.js
+++ b/src/js/components/SampleTable/SampleInfo.js
@@ -77,36 +77,36 @@ export function SampleInfo(sources) {
 
   // Don't allow propagation of the event when the click is on .filtersZoom or .informationDetailsZoom
   // Otherwise it will propagate to .zoom and close the row details instead of opening/closing .filtersZoom or .informationDetailsZoom
-  // This code doesn't quite follow the cycle.js dogma
-  xs.merge(clickFilters$, clickInfoDetails$)
-    .addListener({
-      next: (ev) => { ev.stopPropagation() },
-      error: () => {}
-    })
-
+  // Calling ev.stopPropagation() this way doesn't quite follow the cycle.js dogma
   const zoomInfo$ = xs.merge(
-    clickRow$.mapTo("row"),
-    clickFilters$.mapTo("filters"),
-    clickInfoDetails$.mapTo("infoDetails")
+    clickRow$.map(ev => [ev, "row"]),
+    clickFilters$.map(ev => [ev, "filters"]),
+    clickInfoDetails$.map(ev => [ev, "infoDetails"])
     )
-    .fold((acc, ev) => 
+    .fold((acc, [ev, id]) => 
       {
-        if (ev == "row")
+        if (id == "row") {
           return {
             row: !acc.row,
             filters: false,
             infoDetails: false,
           }
-        else if (ev == "filters")
+        }
+        else if (id == "filters") {
+          ev.stopPropagation()
           return {
             ...acc,
             filters: !acc.filters
           }
-        else if (ev = "infoDetails")
+        }
+        else if (id == "infoDetails") {
+          ev.stopPropagation()
           return {
             ...acc,
             infoDetails: !acc.infoDetails
           }
+        }
+        else return acc
       }
       ,
       { row: false, filters: false, infoDetails: false }

--- a/src/js/components/SettingsEditor.js
+++ b/src/js/components/SettingsEditor.js
@@ -9,7 +9,7 @@ import {
   } from "@cycle/dom"
   import xs from "xstream"
   import isolate from "@cycle/isolate"
-  import { merge } from "ramda"
+  import { mergeRight } from "ramda"
   import { pick, mix } from "cycle-onionify"
 
 /**
@@ -82,13 +82,13 @@ export function SettingsEditor(sources) {
       if (config.type == "checkbox") {
         return [
           label(".active", [
-            input({ props: merge(config.props, { checked: _state }) }),
+            input({ props: mergeRight(config.props, { checked: _state }) }),
             span(".lever"),
           ]),
         ]
       }
       if (config.type == "text" || config.type == "range") {
-        return [input({ props: merge(config.props, { value: _state }) })]
+        return [input({ props: mergeRight(config.props, { value: _state }) })]
       }
       if (config.type == "select") {
         const options = config.options
@@ -102,7 +102,7 @@ export function SettingsEditor(sources) {
             { style: { "border-style": "solid", margin: "2px" } },
             [
               label(selectedOption(o), [
-                input("", { props: merge(config.props, { value: o }) }, ""),
+                input("", { props: mergeRight(config.props, { value: o }) }, ""),
                 o,
               ]),
             ]

--- a/src/js/components/SignatureGenerator.js
+++ b/src/js/components/SignatureGenerator.js
@@ -1,14 +1,9 @@
 import sampleCombine from 'xstream/extra/sampleCombine'
-import isolate from '@cycle/isolate'
 import { i, p, div, br, label, input, code, table, tr, td, b, h2, button, textarea, a, ul, li, span, th, thead, tbody, h3 } from '@cycle/dom';
-import { clone, equals, merge, isEmpty } from 'ramda';
+import { clone, equals, isEmpty } from 'ramda';
 import xs from 'xstream';
-// import { logThis, log } from '../utils/logger'
-// import { ENTER_KEYCODE } from '../utils/keycodes.js'
 import dropRepeats from 'xstream/extra/dropRepeats'
-// import delay from 'xstream/extra/delay'
 import { loggerFactory } from '../utils/logger'
-// import { stringify } from 'querystring';
 import { GeneAnnotationQuery } from './GeneAnnotationQuery'
 import { absGene } from '../utils/utils'
 import { busyUiReducer, dirtyWrapperStream } from "../utils/ui"

--- a/src/js/components/Statistics.js
+++ b/src/js/components/Statistics.js
@@ -1,8 +1,6 @@
 import { a, div, br, label, input, p, button, code, pre, span, h5 } from '@cycle/dom'
 import xs from 'xstream'
-import isolate from '@cycle/isolate'
-import { mergeWith, merge } from 'ramda'
-import { clone, equal, equals, mergeAll, omit } from 'ramda';
+import { equals, mergeRight, omit } from 'ramda';
 import dropRepeats from 'xstream/extra/dropRepeats'
 import debounce from 'xstream/extra/debounce'
 
@@ -127,7 +125,7 @@ function Statistics(sources) {
     });
 
     // Add the result to the state
-    const stateReducer$ = data$.map(data => prevState => merge(prevState, { result: data }))
+    const stateReducer$ = data$.map(data => prevState => mergeRight(prevState, { result: data }))
 
     return {
         DOM: vdom$,

--- a/src/js/components/Table.js
+++ b/src/js/components/Table.js
@@ -29,15 +29,11 @@ import { log } from "../utils/logger"
 import { ENTER_KEYCODE } from "../utils/keycodes.js"
 import {
   keys,
-  values,
   filter,
-  head,
   equals,
   map,
   prop,
-  clone,
-  omit,
-  merge,
+  mergeRight,
   intersection,
   difference,
   max,
@@ -48,7 +44,6 @@ import dropRepeats from "xstream/extra/dropRepeats"
 import { loggerFactory } from "../utils/logger"
 import { convertToCSV } from "../utils/export"
 import delay from "xstream/extra/delay"
-import debounce from "xstream/extra/debounce"
 import pairwise from "xstream/extra/pairwise"
 import { dirtyWrapperStream } from "../utils/ui"
 
@@ -410,7 +405,7 @@ function makeTable(tableComponent, tableLens, scope = "scope1") {
      * @type {Stream}
      */
     const request$ = triggerRequest$.map((state) => ({
-      send: merge(state.core.count, {
+      send: mergeRight(state.core.count, {
         query: state.core.input.query,
         version: "v2",
         // filter: (typeof state.core.input.filter !== 'undefined') ? state.core.input.filter : '',

--- a/src/js/components/TargetForm.js
+++ b/src/js/components/TargetForm.js
@@ -1,15 +1,7 @@
-import sampleCombine from 'xstream/extra/sampleCombine'
 import isolate from '@cycle/isolate'
 import { i, p, div, br, label, input, code, table, tr, td, b, h2, button, textarea, a, ul, li, span } from '@cycle/dom';
-import { clone, equals } from 'ramda';
 import xs from 'xstream';
-import { logThis, log } from '../utils/logger'
-import { ENTER_KEYCODE } from '../utils/keycodes.js'
 import { TargetCheck, checkLens } from './TargetCheck'
-import { SampleSelection, sampleSelectionLens } from './SampleSelection'
-import { mergeWith, merge } from 'ramda'
-import { SignatureGenerator, signatureLens } from './SignatureGenerator'
-import { stateDebug } from '../utils/utils'
 import { loggerFactory } from '../utils/logger'
 
 function TargetForm(sources) {

--- a/src/js/components/TreatmentAnnotation.js
+++ b/src/js/components/TreatmentAnnotation.js
@@ -1,11 +1,8 @@
 import { loggerFactory } from '../utils/logger'
 import xs from 'xstream'
-import { keys, values, filter, head, equals, map, prop, clone, omit, merge } from 'ramda'
-import dropRepeats from 'xstream/extra/dropRepeats'
 import { i, em, p, div, br, label, input, code, table, tr, td, b, h2, button, textarea, a, ul, li, span, th, thead, tbody, h3, h4 } from '@cycle/dom';
 import { titleCase } from '../utils/utils'
 import sampleCombine from 'xstream/extra/sampleCombine'
-import delay from 'xstream/extra/delay'
 
 /**
  * This components checks if an elements is clicked and shows a modal when so.

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -22,7 +22,7 @@ import {
   span,
   img,
 } from "@cycle/dom"
-import { merge, prop, mergeDeepLeft, mergeDeepRight, equals, pickBy, identity } from "ramda"
+import { mergeRight, prop, mergeDeepLeft, mergeDeepRight, equals, pickBy, identity } from "ramda"
 import * as R from "ramda"
 
 // Workflows
@@ -327,7 +327,7 @@ export default function Index(sources) {
       desiredDeployment
     )
     // Merge the updated deployment with the settings, by key.
-    const updatedSettings = merge(initSettings, {
+    const updatedSettings = mergeRight(initSettings, {
       deployment: updatedDeployment,
     })
     // Do the same with the administrative settings
@@ -346,7 +346,7 @@ export default function Index(sources) {
       const valueKeys = Object.keys(value)
 
       const present = keys.map((key) => {
-        if (!R.contains(key, valueKeys)) return false
+        if (!R.includes(key, valueKeys)) return false
         if (typeof obj[key] === "object")
           return allPresent(obj[key], value[key])
         return true
@@ -398,7 +398,7 @@ export default function Index(sources) {
         desiredDeployment
       )
       // Merge the updated deployment with the settings, by key.
-      const updatedSettings = merge(prevState.settings, {
+      const updatedSettings = mergeRight(prevState.settings, {
         deployment: updatedDeployment,
       })
       // Do the same with the administrative settings, keep value in settings if exist - only add from deployments if value is missing

--- a/src/js/pages/adminSettings.js
+++ b/src/js/pages/adminSettings.js
@@ -336,7 +336,7 @@ export function AdminSettings(sources) {
         prevState.deployment,
         desiredDeployment
       )
-      const updatedSettings = R.merge(prevState, {
+      const updatedSettings = R.mergeRight(prevState, {
         deployment: updatedDeployment,
       })
       const distributedAdminSettings = R.mergeDeepRight(

--- a/src/js/pages/correlation.js
+++ b/src/js/pages/correlation.js
@@ -1,18 +1,13 @@
 import { a, div, br, label, input, p, button, code, pre } from '@cycle/dom'
 import xs from 'xstream'
 import isolate from '@cycle/isolate'
-import { mergeWith, merge } from 'ramda'
-import { clone, equal, equals, mergeAll } from 'ramda';
-import dropRepeats from 'xstream/extra/dropRepeats'
 
 // Components
 import { CorrelationForm, formLens } from '../components/CorrelationForm'
 import { CorrelationPlot, correlationPlotsLens } from '../components/BinnedPlots/CorrelationPlot'
-import { makeTable, headTableLens, tailTableLens } from '../components/Table'
 import { initSettings } from '../configuration.js'
 import { Filter, filterLens } from '../components/Filter'
 import { loggerFactory } from '../utils/logger'
-import { SampleTable, sampleTableLens } from '../components/SampleTable/SampleTable'
 import { Exporter } from "../components/Exporter"
 
 // Support for ghost mode

--- a/src/js/pages/debug.js
+++ b/src/js/pages/debug.js
@@ -1,15 +1,5 @@
 import xs from 'xstream';
 import { div, nav, a, h3, p, ul, li, h1, h2, i, footer, header, main, svg, g, path, code, pre } from '@cycle/dom';
-import { merge, prop, equals } from 'ramda';
-
-import { Check } from '../components/Check'
-import { IsolatedSettings } from './settings'
-
-import flattenSequentially from 'xstream/extra/flattenSequentially'
-import { pick, mix } from 'cycle-onionify';
-import { initSettings } from './settings'
-import debounce from 'xstream/extra/debounce'
-import dropRepeats from 'xstream/extra/dropRepeats'
 
 import { loggerFactory } from '../utils/logger'
 

--- a/src/js/pages/home.js
+++ b/src/js/pages/home.js
@@ -1,6 +1,6 @@
 import xs from 'xstream';
 import { div, nav, a, h3, p, ul, li, h1, h2, i, footer, header, main, svg, g, path, img, map, area, use, span } from '@cycle/dom'
-import { merge, prop, equals } from 'ramda';
+import { mergeRight, prop, equals } from 'ramda';
 
 import { Check } from '../components/Check'
 import dropRepeats from 'xstream/extra/dropRepeats'
@@ -19,8 +19,8 @@ function Home(sources) {
 
     const checkProps$ = sources.onion.state$
         .compose(dropRepeats((x, y) => equals(x.settings, y.settings)))
-        .map(state => merge(state.settings.form, state.settings.api))
-    const CheckSink = Check(merge(sources, { props: checkProps$ }))
+        .map(state => mergeRight(state.settings.form, state.settings.api))
+    const CheckSink = Check(mergeRight(sources, { props: checkProps$ }))
 
     const makeLink = (path, label, selector) => {
         return li(".home-menu .row",

--- a/src/js/pages/init.js
+++ b/src/js/pages/init.js
@@ -1,7 +1,7 @@
 import xs from "xstream"
 import { div, p, span, button, textarea, input, a } from "@cycle/dom"
 import isolate from "@cycle/isolate"
-import { merge, prop, equals } from "ramda"
+import { prop, equals } from "ramda"
 
 import { initSettings } from "../configuration"
 import { SettingsEditor } from "../components/SettingsEditor"

--- a/src/js/pages/settings.js
+++ b/src/js/pages/settings.js
@@ -4,8 +4,6 @@ import {
 } from "@cycle/dom"
 import xs from "xstream"
 import isolate from "@cycle/isolate"
-import { mergeWith, merge, mergeAll } from "ramda"
-import { pick, mix } from "cycle-onionify"
 import debounce from "xstream/extra/debounce"
 
 import { SettingsEditor } from "../components/SettingsEditor"

--- a/src/js/pages/statistics.js
+++ b/src/js/pages/statistics.js
@@ -1,8 +1,7 @@
 import { a, div, br, label, input, p, button, code, pre } from '@cycle/dom'
 import xs from 'xstream'
 import isolate from '@cycle/isolate'
-import { mergeWith, merge } from 'ramda'
-import { clone, equal, equals, mergeAll, prop, props } from 'ramda';
+import { equals, mergeRight, mergeAll, prop, props } from 'ramda';
 import dropRepeats from 'xstream/extra/dropRepeats'
 
 import { initSettings } from '../configuration.js'
@@ -35,7 +34,7 @@ function StatisticsWorkflow(sources) {
 
   // Add properties to the child component, based on what we need
   const statsProps$ = selectKeysFromSettings(state$, ['stats', 'api'])
-  const statsSinks = isolate(Statistics, 'stats')(merge(sources, { props: statsProps$ }));
+  const statsSinks = isolate(Statistics, 'stats')(mergeRight(sources, { props: statsProps$ }));
 
   const pageStyle = {
     style:

--- a/src/js/pages/target.js
+++ b/src/js/pages/target.js
@@ -1,22 +1,13 @@
 import xs from 'xstream';
 import { div, nav, a, h3, p, ul, li, h1, h2, i, footer, header, main, svg, g, path, input, span } from '@cycle/dom';
-import { merge, prop, equals, mergeAll, mergeWith, mergeDeepRight } from 'ramda';
 
-// import { mockDOMSource } from '@cycle/dom'
-
-import { Check } from '../components/Check'
-import { IsolatedSettings } from './settings'
 import { TargetForm } from '../components/TargetForm'
 import { makeTable, compoundContainerTableLens } from '../components/Table'
 
-import { SampleTable, sampleTableLens } from '../components/SampleTable/SampleTable'
 import { CompoundTable, compoundTableLens } from '../components/CompoundTable/CompoundTable'
 import { Histogram, histLens } from '../components/Histogram/Histogram'
 
-import { pick, mix } from 'cycle-onionify';
 import { initSettings } from '../configuration.js'
-import debounce from 'xstream/extra/debounce'
-import dropRepeats from 'xstream/extra/dropRepeats'
 import { loggerFactory } from '../utils/logger'
 import isolate from '@cycle/isolate'
 import { SignatureForm, formLens } from '../components/SignatureForm'

--- a/src/js/utils/logger.js
+++ b/src/js/utils/logger.js
@@ -1,4 +1,4 @@
-import { merge, prop, equals, path } from 'ramda'
+import { equals, path } from 'ramda'
 import xs from 'xstream'
 import dropRepeats from 'xstream/extra/dropRepeats'
 


### PR DESCRIPTION
- Fix an issue where data refresh causes the top table expansion functionality locking up caused by added listeners and streams getting interrupted
- Fix issue when a sample selection filter is removed triggering an update on unavailable data
- Hide outdated sample selection data when retrieving new data due a new selected perturbation
- Update Ramda to recent versions