### PR TITLE
Set the contentSecurityPolicy option in helmet to improve cross-site scripting security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## Version 5.4.2
+
+### Other
+
+- Set the contentSecurityPolicy option in helmet to improve cross-site scripting security
+
+### Deployment changes
+
+- `serverConfiguration.js` should contain valid information matching the deployment infrastructure
+
 ## Version 5.4.1
 
 ### Bug fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "LuciusWeb",
-    "version": "5.4.1",
+    "version": "5.4.2-alpha1",
     "description": "Web interface for ComPass aka Lucius",
     "repository": {
         "type": "git",

--- a/server.js
+++ b/server.js
@@ -1,3 +1,6 @@
+// Own module to contain deployment-specific server.js information
+const serverConfiguration = require("./serverConfiguration.js");
+
 const path = require("path");
 const express = require("express");
 const helmet = require("helmet");
@@ -10,7 +13,7 @@ const app = express();
 app.use(express.static(DIST_DIR));
 
 // Tweak rules so that it allows off-site logo & sourire images
-// app.use(helmet.contentSecurityPolicy());
+app.use(helmet.contentSecurityPolicy( serverConfiguration.contentSecurityPolicy ));
 // app.use(helmet.crossOriginEmbedderPolicy());
 // app.use(helmet.crossOriginOpenerPolicy());
 app.use(helmet.crossOriginResourcePolicy({ policy: "cross-origin" }));

--- a/serverConfiguration.js
+++ b/serverConfiguration.js
@@ -1,0 +1,22 @@
+"use strict"
+
+const serverConfiguration = {
+
+// Sets the content Security Policy in helmet
+// Basically, define which sources are allowed to come from which locations
+// This is a default value that works with a local host, Spark Jobserver and a Sourire instance
+  contentSecurityPolicy: {
+    directives: {
+      defaultSrc: ["'self'"],
+      scriptSrc: ["'self'", "'unsafe-inline'", "'unsafe-eval'"],
+      connectSrc: ["localhost:3080", "localhost:8090"],
+      styleSrc: ["'self'", "'unsafe-inline'", "fonts.googleapis.com"],
+      imgSrc: ["'self'", "localhost:9999", "www.data-intuitive.com"],
+    }
+  }
+}
+
+exports = serverConfiguration
+module.exports = serverConfiguration
+
+exports["default"] = serverConfiguration


### PR DESCRIPTION
`serverConfiguration.js` should contain valid information matching the deployment infrastructure